### PR TITLE
Add fix to build without having gem installed

### DIFF
--- a/lib/rubygems/precompiler.rb
+++ b/lib/rubygems/precompiler.rb
@@ -87,6 +87,16 @@ class Gem::Precompiler
       tempdir do |workroot|
         extract_files_into(workroot)
 
+        # HACK HACK HACK!!!
+        # i feel sad writing this but can't see a simpler way ?
+        class <<@spec
+          attr_accessor :workroot
+          def full_gem_path
+            return workroot
+          end
+        end
+        @spec.workroot = workroot
+
         @spec.extension_dir = install_root
         @spec.installed_by_version = Gem::VERSION
         @spec.build_extensions


### PR DESCRIPTION
Without this fix gem precompile would only succeed if the gem was
installed. This fixes that.

The problem is the builder calls spec.gem_full_path to figure out where
to start the build. This is made of gem_dir + extension name. We extract
them gem to a temporary location and do not install to gem_dir.

There is no easy way to pass gem_dir along so we can set it when the
builder accesses it. So the only clean way around this appears to be
patching the Spec to return the gem_full_path pointing to our workroot.

This fixes precompile so it will build all gems without them been installed.