### PR TITLE
Fix for rubygems 2.6 & tests

### DIFF
--- a/features/installing_with_cache.feature
+++ b/features/installing_with_cache.feature
@@ -3,8 +3,6 @@ Feature: Installing using a compiled-cache
   Background:
     Given I have wiped the folder "/tmp/precompiled-workroot"
 
-#  Scenario: Installing a compiled gem without the cache
-
   Scenario: Installing a compiled gem with a cache miss
     Given I use the gem configuration option
       """
@@ -18,12 +16,11 @@ Feature: Installing using a compiled-cache
 
     When I execute
       """
-      echo "puts CompiledClass.new.test_method" | ruby -I/tmp/precompiled-workroot/installroot/gems/compiled-gem-0.0.1/lib -rtest_ext/test_ext
+      echo "puts CompiledClass.new.test_method" | ruby -I "/tmp/precompiled-workroot/installroot/extensions/x86_64-darwin-15/2.1.0-static/compiled-gem-0.0.1" -r "test_ext/test_ext"
       """
 
     Then I should see "Hello, world!"
 
-  # this works in reality but the test is dodgy on ruby 2. Needs investment in time to fix
   Scenario: Installing a compiled gem with a cache hit
     Given I use the gem configuration option
       """
@@ -40,7 +37,7 @@ Feature: Installing using a compiled-cache
 
     When I execute
       """
-      echo "puts CompiledClass.new.test_method" | ruby -I/tmp/precompiled-workroot/installroot/gems/compiled-gem-0.0.1/lib -rtest_ext/test_ext
+      echo "puts CompiledClass.new.test_method" | ruby -I "/tmp/precompiled-workroot/installroot/extensions/x86_64-darwin-15/2.1.0-static/compiled-gem-0.0.1" -r "test_ext/test_ext"
       """
 
     Then I should see "Hello, world!"

--- a/features/installing_with_cache.feature
+++ b/features/installing_with_cache.feature
@@ -14,9 +14,10 @@ Feature: Installing using a compiled-cache
     Then I should see "Building native extensions"
     Then I should not see "Loading native extension from cache"
 
-    When I execute
+    When I run ruby
       """
-      echo "puts CompiledClass.new.test_method" | ruby -I "/tmp/precompiled-workroot/installroot/extensions/x86_64-darwin-15/2.1.0-static/compiled-gem-0.0.1" -r "test_ext/test_ext"
+      require "test_ext/test_ext"
+      puts CompiledClass.new.test_method
       """
 
     Then I should see "Hello, world!"
@@ -35,9 +36,10 @@ Feature: Installing using a compiled-cache
     Then I should not see "Building native extensions"
     Then I should see "Loading native extension from cache"
 
-    When I execute
+    When I run ruby
       """
-      echo "puts CompiledClass.new.test_method" | ruby -I "/tmp/precompiled-workroot/installroot/extensions/x86_64-darwin-15/2.1.0-static/compiled-gem-0.0.1" -r "test_ext/test_ext"
+      require "test_ext/test_ext"
+      puts CompiledClass.new.test_method
       """
 
     Then I should see "Hello, world!"

--- a/features/steps/command_steps.rb
+++ b/features/steps/command_steps.rb
@@ -35,14 +35,25 @@ def execute(command)
   puts @last_stderr
 end
 
-When /^I (?:run the command|execute) "(.*?)"( ignoring the exit code)?$/ do |command,ignore_exit_code|
+When /^I (?:run ruby)$/ do |command|
+  extension_path = "/tmp/precompiled-workroot/installroot/extensions/#{Gem::Platform.local}/" \
+    "#{RbConfig::CONFIG["ruby_version"]}-static/compiled-gem-0.0.1"
+
+  cmd = %{cat <<RUBY | ruby -I "#{extension_path}"
+#{command}
+RUBY}
+  execute(cmd)
+  raise RuntimeError, "Command '#{command}' exited with non-zero exit status" unless @last_status == 0
+end
+
+When /^I (?:run the command|execute) "(.*?)"( ignoring the exit code)?$/ do |command, ignore_exit_code|
   execute(command)
   raise RuntimeError, "Command '#{command}' exited with non-zero exit status" unless ignore_exit_code or @last_status == 0
-
 end
+
 When /^I (?:run the command|execute)$/ do |command|
-    execute(command)
-    raise RuntimeError, "Command '#{command}' exited with non-zero exit status" unless @last_status == 0
+  execute(command)
+  raise RuntimeError, "Command '#{command}' exited with non-zero exit status" unless @last_status == 0
 end
 
 Then /^I should( not)? see "(.*?)"( on (stdout|stderr))?$/ do |invert, expect, any, channel|

--- a/features/steps/command_steps.rb
+++ b/features/steps/command_steps.rb
@@ -76,7 +76,7 @@ Then /^the command should leave behind temporary directories/ do
   data = @last_stdout + @last_stderr
   data.each_line do |l|
     if m = l.match(/Leaving (.*) in place/)
-      expect(Dir.exists?(m[1])).to be_true
+      expect(Dir.exists?(m[1])).to be true
     end
   end
 end

--- a/features/steps/file_steps.rb
+++ b/features/steps/file_steps.rb
@@ -21,6 +21,7 @@ Given /^I have changed to a temporary directory(?: containing "(.*?)")?$/ do |gl
   FileUtils.chdir(directory)
 end
 After do
+  FileUtils.chdir(OriginalWorkingDirectory)
   cleanup.each { |dir| FileUtils.rm_rf(dir) }
 end
 

--- a/features/steps/file_steps.rb
+++ b/features/steps/file_steps.rb
@@ -26,7 +26,7 @@ After do
 end
 
 Then /^the folder "(.*?)" should exist$/ do |folder|
-  File.directory?(folder).should be_true
+  expect(File.directory?(folder)).to be true
 end
 
 Then /^the file "(.*?)" should (not )?exist$/ do |file, invert|

--- a/lib/rubygems/precompiled.rb
+++ b/lib/rubygems/precompiled.rb
@@ -23,9 +23,11 @@ module Precompiled
     def retrieve(spec)
       raise "Must be overriden!"
     end
+
     def contains?(spec)
       false
     end
+
     def cache_key(spec)
       "/ruby-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}/#{Gem::Platform.local.to_s}/#{spec.name}-#{spec.version}.tar.gz"
     end
@@ -35,6 +37,7 @@ module Precompiled
     def path_for(spec)
       File.join(@root_uri.path, cache_key(spec))
     end
+
     def contains?(spec)
       File.exists?(path_for(spec))
     end
@@ -48,11 +51,13 @@ module Precompiled
     def uri_to_spec(spec)
       URI.join(@root_uri, File.join(@root_uri.path, cache_key(spec)))
     end
+
     def contains?(spec)
       uri = uri_to_spec(spec)
       http = Net::HTTP.start(uri.host, uri.port)
       http.head(uri.path).code == "200"
     end
+
     def retrieve(spec)
       tempfile = Tempfile.new('cache-hit')
       uri = uri_to_spec(spec)
@@ -102,7 +107,7 @@ module Precompiled
     end
   end
 
-  # Private: Extracts a .tar.gz file on-top of the gem's installation directory
+  # Private: Extracts a .tar.gz file on-top of the gem's installation directory
   def overlay_tarball(tarball, target_root)
     Zlib::GzipReader.open(tarball) do |gzip_io|
       Gem::Package::TarReader.new(gzip_io) do |tar|

--- a/lib/rubygems/precompiled.rb
+++ b/lib/rubygems/precompiled.rb
@@ -12,11 +12,6 @@ require 'uri'
 require 'tempfile'
 
 module Precompiled
-  def self.included(base)
-    base.send(:alias_method, :build_extensions_without_cache, :build_extensions)
-    base.send(:alias_method, :build_extensions, :build_extensions_with_cache)
-  end
-
   GemCache = {
     'file' => FileCache,
     'http' => HttpCache
@@ -32,44 +27,51 @@ module Precompiled
     end
   end
 
-  def build_extensions_with_cache
-    spec = @package.spec
-    cache = Precompiled.precompiled_caches.find { |cache| cache.contains?(spec) }
-
-    if cache
-      $stderr.puts "Loading native extension from cache"
-      cache.retrieve(spec) do |path|
-        if spec.respond_to?(:extension_dir)
-          overlay_tarball(path, spec.extension_dir)
-        else
-          overlay_tarball(path, @gem_dir)
-        end
-      end
-    else
-      build_extensions_without_cache
+  module InstallerExtension
+    def self.included(base)
+      base.send(:alias_method, :build_extensions_without_cache, :build_extensions)
+      base.send(:alias_method, :build_extensions, :build_extensions_with_cache)
     end
-  end
 
-  # Private: Extracts a .tar.gz file on-top of the gem's installation directory
-  def overlay_tarball(tarball, target_root)
-    Zlib::GzipReader.open(tarball) do |gzip_io|
-      Gem::Package::TarReader.new(gzip_io) do |tar|
-        tar.each do |entry|
-          target_path = File.join(target_root, entry.full_name)
-          if entry.directory?
-            FileUtils.mkdir_p(target_path)
-          elsif entry.file?
-            FileUtils.mkdir_p(File.dirname(target_path))
-            File.open(target_path, "w") do |f|
-              f.write entry.read(1024*1024) until entry.eof?
-            end
+
+    def build_extensions_with_cache
+      spec = @package.spec
+      cache = Precompiled.precompiled_caches.find { |cache| cache.contains?(spec) }
+
+      if cache
+        $stderr.puts "Loading native extension from cache"
+        cache.retrieve(spec) do |path|
+          if spec.respond_to?(:extension_dir)
+            precompile_overlay_tarball(path, spec.extension_dir)
+          else
+            precompile_overlay_tarball(path, @gem_dir)
           end
-          entry.close
         end
-       end
+      else
+        build_extensions_without_cache
+      end
+    end
+
+    # Private: Extracts a .tar.gz file on-top of the gem's installation directory
+    def precompile_overlay_tarball(tarball, target_root)
+      Zlib::GzipReader.open(tarball) do |gzip_io|
+        Gem::Package::TarReader.new(gzip_io) do |tar|
+          tar.each do |entry|
+            target_path = File.join(target_root, entry.full_name)
+            if entry.directory?
+              FileUtils.mkdir_p(target_path)
+            elsif entry.file?
+              FileUtils.mkdir_p(File.dirname(target_path))
+              File.open(target_path, "w") do |f|
+                f.write entry.read(1024*1024) until entry.eof?
+              end
+            end
+            entry.close
+          end
+         end
+      end
     end
   end
-
 end
 
-Gem::Installer.send(:include, Precompiled)
+Gem::Installer.send(:include, Precompiled::InstallerExtension)

--- a/lib/rubygems/precompiled.rb
+++ b/lib/rubygems/precompiled.rb
@@ -85,13 +85,14 @@ module Precompiled
   end
 
   def build_extensions_with_cache
-    cache = Precompiled.precompiled_caches.find { |cache| cache.contains?(@spec) }
+    spec = @package.spec
+    cache = Precompiled.precompiled_caches.find { |cache| cache.contains?(spec) }
 
     if cache
       $stderr.puts "Loading native extension from cache"
-      cache.retrieve(@spec) do |path|
-        if @spec.respond_to?(:extension_dir)
-          overlay_tarball(path, @spec.extension_dir)
+      cache.retrieve(spec) do |path|
+        if spec.respond_to?(:extension_dir)
+          overlay_tarball(path, spec.extension_dir)
         else
           overlay_tarball(path, @gem_dir)
         end

--- a/lib/rubygems/precompiled/base_cache.rb
+++ b/lib/rubygems/precompiled/base_cache.rb
@@ -1,0 +1,19 @@
+module Precompiled
+  class BaseCache
+    def initialize(root_uri)
+      @root_uri = root_uri
+    end
+
+    def retrieve(spec)
+      raise "Must be overriden!"
+    end
+
+    def contains?(spec)
+      false
+    end
+
+    def cache_key(spec)
+      "/ruby-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}/#{Gem::Platform.local.to_s}/#{spec.name}-#{spec.version}.tar.gz"
+    end
+  end
+end

--- a/lib/rubygems/precompiled/file_cache.rb
+++ b/lib/rubygems/precompiled/file_cache.rb
@@ -1,0 +1,17 @@
+require "rubygems/precompiled/base_cache"
+
+module Precompiled
+  class FileCache < BaseCache
+    def path_for(spec)
+      File.join(@root_uri.path, cache_key(spec))
+    end
+
+    def contains?(spec)
+      File.exists?(path_for(spec))
+    end
+
+    def retrieve(spec)
+      yield path_for(spec)
+    end
+  end
+end

--- a/lib/rubygems/precompiled/http_cache.rb
+++ b/lib/rubygems/precompiled/http_cache.rb
@@ -1,0 +1,30 @@
+require "rubygems/precompiled/base_cache"
+
+module Precompiled
+  class HttpCache < BaseCache
+    def uri_to_spec(spec)
+      URI.join(@root_uri, File.join(@root_uri.path, cache_key(spec)))
+    end
+
+    def contains?(spec)
+      uri = uri_to_spec(spec)
+      http = Net::HTTP.start(uri.host, uri.port)
+      http.head(uri.path).code == "200"
+    end
+
+    def retrieve(spec)
+      tempfile = Tempfile.new('cache-hit')
+      uri = uri_to_spec(spec)
+      http = Net::HTTP.start(uri.host, uri.port)
+      http.request_get(uri.path) do |resp|
+        resp.read_body do |segment|
+          tempfile.write(segment)
+        end
+        tempfile.close
+      end
+
+      yield tempfile
+      tempfile.delete
+    end
+  end
+end

--- a/lib/rubygems/precompiler.rb
+++ b/lib/rubygems/precompiler.rb
@@ -34,34 +34,34 @@ class Gem::Precompiler
     end
   end
 
-  # Private: Extracts the gem files into the specified path
+  # Private: Extracts the gem files into the specified path
   #
   def extract_files_into(dir)
     @installer.unpack(dir)
   end
 
-  # Public: Returns the name of the gem
+  # Public: Returns the name of the gem
   #
   # Returns a string
   def gem_name
     @spec.name
   end
 
-  # Public: Returns the version string of the gem
+  # Public: Returns the version string of the gem
   #
-  # Returns a Gem::Version
+  # Returns a Gem::Version
   def gem_version
     @spec.version
   end
 
-  # Public: Returns the relative require-paths specified by the gem
+  # Public: Returns the relative require-paths specified by the gem
   #
   # Returns an array of strings
   def gem_require_paths
     @spec.require_paths
   end
 
-  # Public: Does the gem actually have any compiled extensions?
+  # Public: Does the gem actually have any compiled extensions?
   #
   # Returns boolean - true if the gem has a c-extension that needs building
   def has_extension?
@@ -96,7 +96,7 @@ class Gem::Precompiler
     File.join(*[@target_dir, "#{gem_name}-#{gem_version.to_s}.tar.gz"].compact)
   end
 
-  # Private: Calls the code necessary to build all the extensions
+  # Private: Calls the code necessary to build all the extensions
   # into a specified install root
   #
   # Returns a list of files beneath that root making up the build
@@ -171,7 +171,7 @@ class Gem::Precompiler
     FileUtils.mv(temp_output.path, output_path)
   end
 
-  # Private: Yield a reference to a TarWriter that writes to
+  # Private: Yield a reference to a TarWriter that writes to
   # the specified .tar.gz file
   #
   def targz_file(path, &block)

--- a/rubygems-precompiled.gemspec
+++ b/rubygems-precompiled.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "cucumber"
 end


### PR DESCRIPTION
Fixes #6 by using the package instance to look up the spec, rather than relying on `@spec` which has now been removed in the `Gem::Installer` instance.

Also moves around the code slightly, and tidies up the bit we're patching `Rubygems::Installer` with. (When we go ruby >= 2 and drop 1.9.3 we'll be able to drop `alias_method` and use `Module#prepend` with `super` instead.)

And finally the tests are fixed up (which fixes #5 to boot.) They run across 1.9, 2.1 & 2.3 (see below), using the correct LOAD_PATH for each version of ruby by querying the runtime before shelling out to check if the extension can be loaded or not. (Also pins to a stable version of RSpec and uses expectations that work on that version.)

```
Otho:rubygems-precompiled(fix_rubygems_2_6) caius$ chrubies 1.9.3,2.1.8,2.3.1 cucumber --quiet -f progress         
>> 1.9.3 => cucumber --quiet -f progress
ruby 1.9.3p551 (2014-11-13) [x86_64-darwin15.0.0]

11 scenarios (11 passed)
53 steps (53 passed)


>> 2.1.8 => cucumber --quiet -f progress
ruby 2.1.8p440 (2015-12-16 revision 53160) [x86_64-darwin15.0]

11 scenarios (11 passed)
53 steps (53 passed)


>> 2.3.1 => cucumber --quiet -f progress
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin15]

11 scenarios (11 passed)
53 steps (53 passed)
```