### PR TITLE
Fix tests & code to work against rubygems 1.8 up through 2.6

### DIFF
--- a/features/precompiling_gems.feature
+++ b/features/precompiling_gems.feature
@@ -28,6 +28,7 @@ Feature: Pre-compiling gems
     And the command should return a success status code
 
   Scenario: Pre-compiling a single compiled gem with --build-config
+    Given this version of rubygems supports build options
     When I run the command "gem precompile --verbose --build-config='--foo --bar' compiled-gem.gem"
 
     Then I should see "build-args --foo --bar"

--- a/features/steps/command_steps.rb
+++ b/features/steps/command_steps.rb
@@ -36,8 +36,12 @@ def execute(command)
 end
 
 When /^I (?:run ruby)$/ do |command|
-  extension_path = "/tmp/precompiled-workroot/installroot/extensions/#{Gem::Platform.local}/" \
-    "#{RbConfig::CONFIG["ruby_version"]}-static/compiled-gem-0.0.1"
+  installroot = "/tmp/precompiled-workroot/installroot"
+  extension_path = if Gem::Version.new(Gem::VERSION) < Gem::Version.new("2.0.0")
+    "#{installroot}/gems/compiled-gem-0.0.1/lib"
+  else
+    "#{installroot}/extensions/#{Gem::Platform.local}/#{RbConfig::CONFIG["ruby_version"]}-static/compiled-gem-0.0.1"
+  end
 
   cmd = %{cat <<RUBY | ruby -I "#{extension_path}"
 #{command}

--- a/features/steps/rubygem_steps.rb
+++ b/features/steps/rubygem_steps.rb
@@ -1,0 +1,6 @@
+Given /this version of rubygems supports build options/ do
+  require "rubygems/installer"
+  unless Gem::Installer.method_defined?(:write_build_info_file)
+    pending "This test will not pass on this version of rubygems."
+  end
+end

--- a/lib/rubygems/precompiled.rb
+++ b/lib/rubygems/precompiled.rb
@@ -35,7 +35,6 @@ module Precompiled
 
 
     def build_extensions_with_cache
-      spec = @package.spec
       cache = Precompiled.precompiled_caches.find { |cache| cache.contains?(spec) }
 
       if cache


### PR DESCRIPTION
Turns out our last PR to support ruby 1.9-2.3 didn't take into account supporting versions of rubygems <= 2.0.

This PR adds back support for rubygems 1.8, and also fixes up the tests to work on ruby {1.9,2.1,2.3} against rubygems {1.8,2.5,2.6}.